### PR TITLE
fix: register gonertia middleware in router

### DIFF
--- a/pkg/handlers/router.go
+++ b/pkg/handlers/router.go
@@ -57,6 +57,7 @@ func BuildRouter(c *services.Container) error {
 			CookieSameSite: http.SameSiteStrictMode,
 			ContextKey:     context.CSRFKey,
 		}),
+		echo.WrapMiddleware(c.Inertia.Middleware),
 		middleware.InertiaProps(), // leave this as the last one
 	)
 


### PR DESCRIPTION
## Summary

- Register `c.Inertia.Middleware` in the Echo middleware chain via `echo.WrapMiddleware()`, placed right before `middleware.InertiaProps()`
- This middleware is essential for the InertiaJS protocol but was missing from the router

## What this middleware does

1. **Converts 302 → 303 for PUT/PATCH/DELETE** — Without this, the browser follows the redirect keeping the original HTTP method (per the Fetch API spec), resulting in 404s
2. **Asset versioning** — Forces a full page reload when frontend assets change, comparing `X-Inertia-Version` header
3. **`Vary: X-Inertia` header** — Tells caches (CDN, proxy) that the response varies based on the `X-Inertia` header
4. **Empty response handling** — Redirects the user back if an Inertia handler returns nothing

## Why it wasn't caught earlier

Currently all delete routes use `POST` (e.g., `profile.POST("/delete", ...)`), so the 302→303 issue doesn't manifest. However, any future route using DELETE/PUT/PATCH with a redirect would break.

## Test plan

- [x] `go build -o /dev/null ./cmd/web` — compiles without errors
- [x] `make test` — all tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)